### PR TITLE
Switch the libraries used for unit testing to Shouldly.

### DIFF
--- a/tests/VariantEnum.Tests/UnitTests.cs
+++ b/tests/VariantEnum.Tests/UnitTests.cs
@@ -1,6 +1,7 @@
-using FluentAssertions;
+using Shouldly;
 using System.Buffers;
 using System.Runtime.InteropServices.Marshalling;
+using Xunit;
 
 namespace VariantEnum.Tests;
 
@@ -9,7 +10,7 @@ public class NoneTest
     [Fact]
     public void Count()
     {
-        None.Count.Should().Be(0);
+        None.Count.ShouldBe(0);
     }
 
     [Fact]
@@ -22,7 +23,7 @@ public class NoneTest
     public void GetNames()
     {
         var names = None.GetNames();
-        names.Length.Should().Be(0);
+        names.Length.ShouldBe(0);
     }
 
     [Fact]
@@ -40,7 +41,7 @@ public class NoneTest
     [Fact]
     public void TryConvertEnum()
     {
-        None.TryConvertEnum(null, out var _).Should().BeFalse();
+        None.TryConvertEnum(null, out var _).ShouldBeFalse();
     }
 
     [Fact]
@@ -54,17 +55,17 @@ public class NoneTest
     [Fact]
     public void TryParse()
     {
-        None.TryParse("None", out var _).Should().BeFalse();
-        None.TryParse("None".AsSpan(), out var _).Should().BeFalse();
-        None.TryParse("None", true, null, out var _).Should().BeFalse();
+        None.TryParse("None", out var _).ShouldBeFalse();
+        None.TryParse("None".AsSpan(), out var _).ShouldBeFalse();
+        None.TryParse("None", true, null, out var _).ShouldBeFalse();
     }
 
     [Fact]
     public void IsDefined()
     {
-        None.IsDefined("None").Should().BeFalse();
+        None.IsDefined("None").ShouldBeFalse();
 
-        None.IsDefined((None)default).Should().BeFalse();
+        None.IsDefined((None)default).ShouldBeFalse();
     }
 }
 
@@ -77,23 +78,23 @@ public class IpAddrTest
             var v4 = new IpAddr.V4(127, 0, 0, 1);
             var v42 = new IpAddr.V4(127, 0, 0, 1);
 
-            v4.Should().Be(v42);
+            v4.ShouldBe(v42);
         }
         {
             var v4 = new IpAddr.V4(127, 0, 0, 1);
             var v42 = new IpAddr.V4(127, 0, 0, 2);
 
-            v4.Should().NotBe(v42);
+            v4.ShouldNotBe(v42);
         }
         {
             var v6 = new IpAddr.V6("::1");
             var v62 = new IpAddr.V6("::1");
-            v6.Should().Be(v62);
+            v6.ShouldBe(v62);
         }
         {
             var v6 = new IpAddr.V6("::1");
             var v62 = new IpAddr.V6("::");
-            v6.Should().NotBe(v62);
+            v6.ShouldNotBe(v62);
         }
     }
 
@@ -103,42 +104,42 @@ public class IpAddrTest
         var buffer = new ArrayBufferWriter<char>(1024);
 
         var v4 = new IpAddr.V4(127, 0, 0, 1);
-        v4.TryFormat(buffer.GetSpan(1024), out var charsWritten).Should().BeTrue();
+        v4.TryFormat(buffer.GetSpan(1024), out var charsWritten).ShouldBeTrue();
         buffer.Advance(charsWritten);
-        v4.ToString().AsSpan().SequenceEqual(buffer.WrittenSpan).Should().BeTrue();
+        v4.ToString().AsSpan().SequenceEqual(buffer.WrittenSpan).ShouldBeTrue();
 
         buffer.Clear();
 
         var v6 = new IpAddr.V6("::1");
-        v6.TryFormat(buffer.GetSpan(1024), out var charsWritten2).Should().BeTrue();
+        v6.TryFormat(buffer.GetSpan(1024), out var charsWritten2).ShouldBeTrue();
         buffer.Advance(charsWritten2);
-        v6.ToString().AsSpan().SequenceEqual(buffer.WrittenSpan).Should().BeTrue();
+        v6.ToString().AsSpan().SequenceEqual(buffer.WrittenSpan).ShouldBeTrue();
 
         buffer.Clear();
 
         var none = new IpAddr.None();
-        none.TryFormat(buffer.GetSpan(1024), out var charsWritten3).Should().BeTrue();
+        none.TryFormat(buffer.GetSpan(1024), out var charsWritten3).ShouldBeTrue();
         buffer.Advance(charsWritten3);
-        none.ToString().AsSpan().SequenceEqual(buffer.WrittenSpan).Should().BeTrue();
+        none.ToString().AsSpan().SequenceEqual(buffer.WrittenSpan).ShouldBeTrue();
     }
 
     [Fact]
     public void ValidateVariant()
     {
         var v4 = new IpAddr.V4(127, 0, 0, 1);
-        v4.args0.Should().Be(127);
-        v4.args1.Should().Be(0);
-        v4.args2.Should().Be(0);
-        v4.args3.Should().Be(1);
+        v4.args0.ShouldBe((byte)127);
+        v4.args1.ShouldBe((byte)0);
+        v4.args2.ShouldBe((byte)0);
+        v4.args3.ShouldBe((byte)1);
 
         var v6 = new IpAddr.V6("::1");
-        v6.args0.Should().Be("::1");
+        v6.args0.ShouldBe("::1");
     }
 
     [Fact]
     public void Count()
     {
-        IpAddr.Count.Should().Be(3);
+        IpAddr.Count.ShouldBe(3);
     }
 
     [Fact]
@@ -148,11 +149,11 @@ public class IpAddrTest
         var v6 = new IpAddr.V6("::1");
         var none = new IpAddr.None();
 
-        IpAddr.GetName(v4).Should().Be(nameof(IpAddr.V4));
-        IpAddr.GetName(v6).Should().Be(nameof(IpAddr.V6));
-        IpAddr.GetName(none).Should().Be(nameof(IpAddr.None));
+        IpAddr.GetName(v4).ShouldBe(nameof(IpAddr.V4));
+        IpAddr.GetName(v6).ShouldBe(nameof(IpAddr.V6));
+        IpAddr.GetName(none).ShouldBe(nameof(IpAddr.None));
 
-        IpAddr.GetName((IpAddr)default).Should().BeNull();
+        IpAddr.GetName((IpAddr)default).ShouldBeNull();
     }
 
     [Fact]
@@ -160,10 +161,10 @@ public class IpAddrTest
     {
         var names = IpAddr.GetNames();
 
-        names[0].Should().Be(nameof(IpAddr.V4));
-        names[1].Should().Be(nameof(IpAddr.V6));
-        names[2].Should().Be(nameof(IpAddr.None));
-        names.Length.Should().Be(3);
+        names[0].ShouldBe(nameof(IpAddr.V4));
+        names[1].ShouldBe(nameof(IpAddr.V6));
+        names[2].ShouldBe(nameof(IpAddr.None));
+        names.Length.ShouldBe(3);
     }
 
     [Fact]
@@ -173,9 +174,9 @@ public class IpAddrTest
         var v6 = new IpAddr.V6("::1");
         var none = new IpAddr.None();
 
-        IpAddr.GetNumericValue(v4).Should().Be((byte)IpAddrVariant.V4);
-        IpAddr.GetNumericValue(v6).Should().Be((byte)IpAddrVariant.V6);
-        IpAddr.GetNumericValue(none).Should().Be((byte)IpAddrVariant.None);
+        IpAddr.GetNumericValue(v4).ShouldBe((byte)IpAddrVariant.V4);
+        IpAddr.GetNumericValue(v6).ShouldBe((byte)IpAddrVariant.V6);
+        IpAddr.GetNumericValue(none).ShouldBe((byte)IpAddrVariant.None);
 
         Assert.Throws<ArgumentException>(() => IpAddr.GetNumericValue(null));
     }
@@ -187,9 +188,9 @@ public class IpAddrTest
         var v6 = new IpAddr.V6("::1");
         var none = new IpAddr.None();
 
-        IpAddr.ConvertEnum(v4).Should().Be(IpAddrVariant.V4);
-        IpAddr.ConvertEnum(v6).Should().Be(IpAddrVariant.V6);
-        IpAddr.ConvertEnum(none).Should().Be(IpAddrVariant.None);
+        IpAddr.ConvertEnum(v4).ShouldBe(IpAddrVariant.V4);
+        IpAddr.ConvertEnum(v6).ShouldBe(IpAddrVariant.V6);
+        IpAddr.ConvertEnum(none).ShouldBe(IpAddrVariant.None);
 
         Assert.Throws<ArgumentException>(() => IpAddr.ConvertEnum(null));
     }
@@ -201,25 +202,25 @@ public class IpAddrTest
         var v6 = new IpAddr.V6("::1");
         var none = new IpAddr.None();
 
-        IpAddr.TryConvertEnum(v4, out var v4Enum).Should().BeTrue();
-        v4Enum.Should().Be(IpAddrVariant.V4);
-        IpAddr.TryConvertEnum(v6, out var v6Enum).Should().BeTrue();
-        v6Enum.Should().Be(IpAddrVariant.V6);
-        IpAddr.TryConvertEnum(none, out var noneEnum).Should().BeTrue();
-        noneEnum.Should().Be(IpAddrVariant.None);
+        IpAddr.TryConvertEnum(v4, out var v4Enum).ShouldBeTrue();
+        v4Enum.ShouldBe(IpAddrVariant.V4);
+        IpAddr.TryConvertEnum(v6, out var v6Enum).ShouldBeTrue();
+        v6Enum.ShouldBe(IpAddrVariant.V6);
+        IpAddr.TryConvertEnum(none, out var noneEnum).ShouldBeTrue();
+        noneEnum.ShouldBe(IpAddrVariant.None);
 
-        IpAddr.TryConvertEnum(null, out var _).Should().BeFalse();
+        IpAddr.TryConvertEnum(null, out var _).ShouldBeFalse();
     }
 
     [Fact]
     public void Parse()
     {
-        IpAddr.Parse("V4").Should().Be(IpAddr.V4.Default);
-        IpAddr.Parse("v4", true).Should().Be(IpAddr.V4.Default);
-        IpAddr.Parse("V6").Should().Be(IpAddr.V6.Default);
-        IpAddr.Parse("v6", true).Should().Be(IpAddr.V6.Default);
-        IpAddr.Parse("None").Should().Be(IpAddr.None.Default);
-        IpAddr.Parse("none", true).Should().Be(IpAddr.None.Default);
+        IpAddr.Parse("V4").ShouldBe(IpAddr.V4.Default);
+        IpAddr.Parse("v4", true).ShouldBe(IpAddr.V4.Default);
+        IpAddr.Parse("V6").ShouldBe(IpAddr.V6.Default);
+        IpAddr.Parse("v6", true).ShouldBe(IpAddr.V6.Default);
+        IpAddr.Parse("None").ShouldBe(IpAddr.None.Default);
+        IpAddr.Parse("none", true).ShouldBe(IpAddr.None.Default);
 
         Assert.Throws<ArgumentException>(() => IpAddr.Parse(string.Empty));
         Assert.Throws<ArgumentException>(() => IpAddr.Parse(string.Empty.AsSpan()));
@@ -229,35 +230,35 @@ public class IpAddrTest
     [Fact]
     public void TryParse()
     {
-        IpAddr.TryParse("V4", out var v4Enum).Should().BeTrue();
-        v4Enum.Should().Be(IpAddr.V4.Default);
-        IpAddr.TryParse("v4", true, null, out v4Enum).Should().BeTrue();
-        v4Enum.Should().Be(IpAddr.V4.Default);
-        IpAddr.TryParse("V6", out var v6Enum).Should().BeTrue();
-        v6Enum.Should().Be(IpAddr.V6.Default);
-        IpAddr.TryParse("v6", true, null, out v6Enum).Should().BeTrue();
-        v6Enum.Should().Be(IpAddr.V6.Default);
-        IpAddr.TryParse("None", out var noneEnum).Should().BeTrue();
-        noneEnum.Should().Be(IpAddr.None.Default);
-        IpAddr.TryParse("none", true, null, out noneEnum).Should().BeTrue();
-        noneEnum.Should().Be(IpAddr.None.Default);
+        IpAddr.TryParse("V4", out var v4Enum).ShouldBeTrue();
+        v4Enum.ShouldBe(IpAddr.V4.Default);
+        IpAddr.TryParse("v4", true, null, out v4Enum).ShouldBeTrue();
+        v4Enum.ShouldBe(IpAddr.V4.Default);
+        IpAddr.TryParse("V6", out var v6Enum).ShouldBeTrue();
+        v6Enum.ShouldBe(IpAddr.V6.Default);
+        IpAddr.TryParse("v6", true, null, out v6Enum).ShouldBeTrue();
+        v6Enum.ShouldBe(IpAddr.V6.Default);
+        IpAddr.TryParse("None", out var noneEnum).ShouldBeTrue();
+        noneEnum.ShouldBe(IpAddr.None.Default);
+        IpAddr.TryParse("none", true, null, out noneEnum).ShouldBeTrue();
+        noneEnum.ShouldBe(IpAddr.None.Default);
 
-        IpAddr.TryParse(string.Empty, out var _).Should().BeFalse();
-        IpAddr.TryParse(string.Empty.AsSpan(), out var _).Should().BeFalse();
-        IpAddr.TryParse(string.Empty, true, null,  out var _).Should().BeFalse();
+        IpAddr.TryParse(string.Empty, out var _).ShouldBeFalse();
+        IpAddr.TryParse(string.Empty.AsSpan(), out var _).ShouldBeFalse();
+        IpAddr.TryParse(string.Empty, true, null,  out var _).ShouldBeFalse();
     }
 
     [Fact]
     public void IsDefined()
     {
-        IpAddr.IsDefined("V4").Should().BeTrue();
-        IpAddr.IsDefined("V6").Should().BeTrue();
-        IpAddr.IsDefined("None").Should().BeTrue();
-        IpAddr.IsDefined(string.Empty).Should().BeFalse();
+        IpAddr.IsDefined("V4").ShouldBeTrue();
+        IpAddr.IsDefined("V6").ShouldBeTrue();
+        IpAddr.IsDefined("None").ShouldBeTrue();
+        IpAddr.IsDefined(string.Empty).ShouldBeFalse();
 
-        IpAddr.IsDefined(new IpAddr.V4(127, 0, 0, 1)).Should().BeTrue();
-        IpAddr.IsDefined(new IpAddr.V6("::1")).Should().BeTrue();
-        IpAddr.IsDefined(new IpAddr.None()).Should().BeTrue();
-        IpAddr.IsDefined((IpAddr)default).Should().BeFalse();
+        IpAddr.IsDefined(new IpAddr.V4(127, 0, 0, 1)).ShouldBeTrue();
+        IpAddr.IsDefined(new IpAddr.V6("::1")).ShouldBeTrue();
+        IpAddr.IsDefined(new IpAddr.None()).ShouldBeTrue();
+        IpAddr.IsDefined((IpAddr)default).ShouldBeFalse();
     }
 }

--- a/tests/VariantEnum.Tests/VariantEnum.Tests.csproj
+++ b/tests/VariantEnum.Tests/VariantEnum.Tests.csproj
@@ -14,8 +14,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This PR switches from Fluent Assertions to Shouldly.
This is because the licence for Fluent Assertions v8 has changed.