### PR TITLE
Fixes bug in generator

### DIFF
--- a/src/VariantEnum/Generator.cs
+++ b/src/VariantEnum/Generator.cs
@@ -41,9 +41,9 @@ public sealed class IgnoreVariantAttribute : Attribute
                     var enumSyntax = node as EnumDeclarationSyntax;
                     if (enumSyntax == null) return false;
 
-                    // enum XXXX
+                    // enum XXXXVariant
                     var enumName = enumSyntax.Identifier.Text;
-                    return enumName.EndsWith("Variant");
+                    return enumName.EndsWith("Variant") && !(enumName == "Variant");
                 }
 
                 return false;


### PR DESCRIPTION
This PR fixes a bug that caused the generator to crash when the enum name is “Variant” alone.

```csharp
public enum Variant : byte
{}
```